### PR TITLE
Add extractor subroutines to CRS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "test-drive"]
 	path = test-drive
-	url = git@github.com:fortran-lang/test-drive.git
+	url = https://github.com/fortran-lang/test-drive.git 

--- a/src/modsparse.f90
+++ b/src/modsparse.f90
@@ -429,6 +429,12 @@ module modsparse
   procedure,public::getmem=>getmem_crs
   !> @brief Initializes the vectors ia,ja,and a from external vectors
   procedure,public::external=>external_crs
+  !> @brief Get function for the internal vector ia of row pointers
+  procedure,public::rowptr=>rowptr_crs
+  !> @brief Get function for the internal vector ja of column values
+  procedure,public::colval=>colval_crs
+  !> @brief Get function for the internal vector a of non-zero values
+  procedure,public::nzval=>nzval_crs
 #if (_SPAINV==1)
   !> @brief Computes and replaces the sparse matrix by an incomplete Cholesky factor
   procedure,public::ichol=>getichol_crs
@@ -528,6 +534,21 @@ module modsparse
    integer(kind=int32),intent(in)::ia(:),ja(:)
    real(kind=wp),intent(in)::a(:)
   end subroutine
+  !**ROWPTR
+  module subroutine rowptr_crs(sparse,ia)
+    class(crssparse),intent(in)::sparse
+    integer(kind=int32),intent(inout)::ia(:)
+  end subroutine
+  !**COLVAL
+  module subroutine colval_crs(sparse,ja)
+    class(crssparse),intent(in)::sparse
+    integer(kind=int32),intent(inout)::ja(:)
+   end subroutine
+  !**NZVAL
+  module subroutine nzval_crs(sparse,a)
+    class(crssparse),intent(in)::sparse
+    real(kind=wp),intent(inout)::a(:)
+  end subroutine  
   !**MULTIPLICATIONS
   module subroutine multgenv_csr(sparse,alpha,trans,x,val,y)
    !Computes y=val*y+alpha*sparse(tranposition)*x

--- a/src/modsparse.f90
+++ b/src/modsparse.f90
@@ -642,17 +642,19 @@ module modsparse
    real(kind=wp),intent(in)::val
   end subroutine
   !**SOLVE
-  module subroutine solve_crs_vector(sparse,x,y)
+  module subroutine solve_crs_vector(sparse,x,y,msglvl)
    !sparse*x=y
    class(crssparse),intent(inout)::sparse
    real(kind=wp),intent(out),contiguous::x(:)
    real(kind=wp),intent(inout),contiguous::y(:)
+   integer(kind=int32),intent(in),optional::msglvl
   end subroutine
-  module subroutine solve_crs_array(sparse,x,y)
+  module subroutine solve_crs_array(sparse,x,y,msglvl)
    !sparse*x=y
    class(crssparse),intent(inout)::sparse
    real(kind=wp),intent(out),contiguous::x(:,:)
    real(kind=wp),intent(inout),contiguous::y(:,:)
+   integer(kind=int32),intent(in),optional::msglvl
   end subroutine
   !**SOLVE WITH A TRIANGULAR FACTOR
   module subroutine isolve_crs(sparse,x,y)

--- a/src/modsparse.f90
+++ b/src/modsparse.f90
@@ -535,17 +535,17 @@ module modsparse
    real(kind=wp),intent(in)::a(:)
   end subroutine
   !**ROWPTR
-  module subroutine rowptr_crs(sparse,ia)
+  module subroutine get_rowptr_crs(sparse,ia)
     class(crssparse),intent(in)::sparse
     integer(kind=int32),intent(inout)::ia(:)
   end subroutine
   !**COLVAL
-  module subroutine colval_crs(sparse,ja)
+  module subroutine get_colval_crs(sparse,ja)
     class(crssparse),intent(in)::sparse
     integer(kind=int32),intent(inout)::ja(:)
    end subroutine
   !**NZVAL
-  module subroutine nzval_crs(sparse,a)
+  module subroutine get_nzval_crs(sparse,a)
     class(crssparse),intent(in)::sparse
     real(kind=wp),intent(inout)::a(:)
   end subroutine  

--- a/src/modsparse.f90
+++ b/src/modsparse.f90
@@ -430,11 +430,11 @@ module modsparse
   !> @brief Initializes the vectors ia,ja,and a from external vectors
   procedure,public::external=>external_crs
   !> @brief Get function for the internal vector ia of row pointers
-  procedure,public::rowptr=>rowptr_crs
+  procedure,public::get_rowptr=>get_rowptr_crs
   !> @brief Get function for the internal vector ja of column values
-  procedure,public::colval=>colval_crs
+  procedure,public::get_colval=>get_colval_crs
   !> @brief Get function for the internal vector a of non-zero values
-  procedure,public::nzval=>nzval_crs
+  procedure,public::get_nzval=>get_nzval_crs
 #if (_SPAINV==1)
   !> @brief Computes and replaces the sparse matrix by an incomplete Cholesky factor
   procedure,public::ichol=>getichol_crs

--- a/src/modsparse.f90
+++ b/src/modsparse.f90
@@ -537,17 +537,17 @@ module modsparse
   !**ROWPTR
   module subroutine get_rowptr_crs(sparse,ia)
     class(crssparse),intent(in)::sparse
-    integer(kind=int32),intent(inout)::ia(:)
+    integer(kind=int32),allocatable,intent(out)::ia(:)
   end subroutine
   !**COLVAL
   module subroutine get_colval_crs(sparse,ja)
     class(crssparse),intent(in)::sparse
-    integer(kind=int32),intent(inout)::ja(:)
+    integer(kind=int32),allocatable,intent(out)::ja(:)
    end subroutine
   !**NZVAL
   module subroutine get_nzval_crs(sparse,a)
     class(crssparse),intent(in)::sparse
-    real(kind=wp),intent(inout)::a(:)
+    real(kind=wp),allocatable,intent(out)::a(:)
   end subroutine  
   !**MULTIPLICATIONS
   module subroutine multgenv_csr(sparse,alpha,trans,x,val,y)

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -212,40 +212,31 @@ end subroutine
 !**rowptr_crs
 module subroutine get_rowptr_crs(sparse,ia)
   class(crssparse),intent(in)::sparse
-  integer(kind=int32),intent(inout)::ia(:)
+  integer(kind=int32),allocatable,intent(out)::ia(:)
  
-  if(size(ia).ne.size(sparse%ia))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array ia is of a different size!'
-   stop
-  endif
- 
+  allocate(ia(size(sparse%ia))) 
   ia=sparse%ia
+
 end subroutine
  
 !**colval_crs
 module subroutine get_colval_crs(sparse,ja)
   class(crssparse),intent(in)::sparse
-  integer(kind=int32),intent(inout)::ja(:)
+  integer(kind=int32),allocatable,intent(out)::ja(:)
  
-  if(size(ja).ne.size(sparse%ja))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array ja is of a different size!'
-   stop
-  endif
- 
+  allocate(ja(size(sparse%ja))) 
   ja=sparse%ja
+
 end subroutine
  
 !**nzval_crs
 module subroutine get_nzval_crs(sparse,a)
   class(crssparse),intent(in)::sparse
-  real(kind=wp),intent(inout)::a(:)
- 
-  if(size(a).ne.size(sparse%a))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array a is of a different size!'
-   stop
-  endif
- 
+  real(kind=wp),allocatable,intent(out)::a(:)
+  
+  allocate(a(size(sparse%a))) 
   a=sparse%a
+
 end subroutine
  
 

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -209,6 +209,49 @@ module subroutine external_crs(sparse,ia,ja,a)
 
 end subroutine
 
+!**rowptr_crs
+module subroutine rowptr_crs(sparse,ia)
+  class(crssparse),intent(in)::sparse
+  integer(kind=int32),intent(inout)::ia(:)
+ 
+  if(size(ia).ne.size(sparse%ia))then
+   write(sparse%unlog,'(a)')' ERROR: The provided array ia is of a different
+size!'
+   stop
+  endif
+ 
+  ia=sparse%ia
+end subroutine
+ 
+!**colval_crs
+module subroutine colval_crs(sparse,ja)
+  class(crssparse),intent(in)::sparse
+  integer(kind=int32),intent(inout)::ja(:)
+ 
+  if(size(ja).ne.size(sparse%ja))then
+   write(sparse%unlog,'(a)')' ERROR: The provided array ja is of a different
+size!'
+   stop
+  endif
+ 
+  ja=sparse%ja
+end subroutine
+ 
+!**nzval_crs
+module subroutine nzval_crs(sparse,a)
+  class(crssparse),intent(in)::sparse
+  real(kind=wp),intent(inout)::a(:)
+ 
+  if(size(a).ne.size(sparse%a))then
+   write(sparse%unlog,'(a)')' ERROR: The provided array a is of a different
+size!'
+   stop
+  endif
+ 
+  a=sparse%a
+end subroutine
+ 
+
 !**MULTIPLICATIONS
 module subroutine multgenv_csr(sparse,alpha,trans,x,val,y)
  !Computes y=val*y+alpha*sparse(tranposition)*x

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -828,11 +828,12 @@ module subroutine solve_crs_vector(sparse,x,y,msglvl)
  integer(kind=int32)::nrhs
  integer(kind=int32)::msglvl_opt
 
+ !$ real(kind=real64)::t1
+
  ! default value if not present
  msglvl_opt=1
  if(present(msglvl)) msglvl_opt=msglvl
 
- !$ real(kind=real64)::t1
 
  if(.not.sparse%issquare())then
   write(sparse%unlog,'(a)')' Warning: the sparse matrix is not squared!'
@@ -940,11 +941,12 @@ module subroutine solve_crs_array(sparse,x,y,msglvl)
  integer(kind=int32)::nrhs
  integer(kind=int32)::msglvl_opt
 
+ !$ real(kind=real64)::t1
+
  ! default value if not present
  msglvl_opt=1
  if(present(msglvl)) msglvl_opt=msglvl
 
- !$ real(kind=real64)::t1
 
  if(.not.sparse%issquare())then
   write(sparse%unlog,'(a)')' Warning: the sparse matrix is not squared!'

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -215,8 +215,7 @@ module subroutine rowptr_crs(sparse,ia)
   integer(kind=int32),intent(inout)::ia(:)
  
   if(size(ia).ne.size(sparse%ia))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array ia is of a different
-size!'
+   write(sparse%unlog,'(a)')' ERROR: The provided array ia is of a different size!'
    stop
   endif
  
@@ -229,8 +228,7 @@ module subroutine colval_crs(sparse,ja)
   integer(kind=int32),intent(inout)::ja(:)
  
   if(size(ja).ne.size(sparse%ja))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array ja is of a different
-size!'
+   write(sparse%unlog,'(a)')' ERROR: The provided array ja is of a different size!'
    stop
   endif
  
@@ -243,8 +241,7 @@ module subroutine nzval_crs(sparse,a)
   real(kind=wp),intent(inout)::a(:)
  
   if(size(a).ne.size(sparse%a))then
-   write(sparse%unlog,'(a)')' ERROR: The provided array a is of a different
-size!'
+   write(sparse%unlog,'(a)')' ERROR: The provided array a is of a different size!'
    stop
   endif
  

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -210,7 +210,7 @@ module subroutine external_crs(sparse,ia,ja,a)
 end subroutine
 
 !**rowptr_crs
-module subroutine rowptr_crs(sparse,ia)
+module subroutine get_rowptr_crs(sparse,ia)
   class(crssparse),intent(in)::sparse
   integer(kind=int32),intent(inout)::ia(:)
  
@@ -223,7 +223,7 @@ module subroutine rowptr_crs(sparse,ia)
 end subroutine
  
 !**colval_crs
-module subroutine colval_crs(sparse,ja)
+module subroutine get_colval_crs(sparse,ja)
   class(crssparse),intent(in)::sparse
   integer(kind=int32),intent(inout)::ja(:)
  
@@ -236,7 +236,7 @@ module subroutine colval_crs(sparse,ja)
 end subroutine
  
 !**nzval_crs
-module subroutine nzval_crs(sparse,a)
+module subroutine get_nzval_crs(sparse,a)
   class(crssparse),intent(in)::sparse
   real(kind=wp),intent(inout)::a(:)
  

--- a/src/modsparse_crs.f90
+++ b/src/modsparse_crs.f90
@@ -816,15 +816,21 @@ end subroutine
 
 !**SOLVE
 #if (_PARDISO==1)
-module subroutine solve_crs_vector(sparse,x,y)
+module subroutine solve_crs_vector(sparse,x,y,msglvl)
  !sparse*x=y
  class(crssparse),intent(inout)::sparse
  real(kind=wp),intent(out),contiguous::x(:)
  real(kind=wp),intent(inout),contiguous::y(:)
+ integer(kind=int32),intent(in),optional::msglvl
 
  !Pardiso variables
  integer(kind=int32)::error
  integer(kind=int32)::nrhs
+ integer(kind=int32)::msglvl_opt
+
+ ! default value if not present
+ msglvl_opt=1
+ if(present(msglvl)) msglvl_opt=msglvl
 
  !$ real(kind=real64)::t1
 
@@ -848,7 +854,7 @@ module subroutine solve_crs_vector(sparse,x,y)
   !Preparation of Cholesky of A with Pardiso
   !parvar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=1)   !mtype=11
   !to avoid ifort 2021.4.0 bug
-  sparse%pardisovar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=1)   !mtype=11
+  sparse%pardisovar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=msglvl_opt)   !mtype=11
 
   !initialize iparm
   call pardisoinit(sparse%pardisovar%pt,sparse%pardisovar%mtype,sparse%pardisovar%iparm)
@@ -922,15 +928,21 @@ module subroutine solve_crs_vector(sparse,x,y)
 
 end subroutine
 
-module subroutine solve_crs_array(sparse,x,y)
+module subroutine solve_crs_array(sparse,x,y,msglvl)
  !sparse*x=y
  class(crssparse),intent(inout)::sparse
  real(kind=wp),intent(out),contiguous::x(:,:)
  real(kind=wp),intent(inout),contiguous::y(:,:)
+ integer(kind=int32),intent(in),optional::msglvl
 
  !Pardiso variables
  integer(kind=int32)::error
  integer(kind=int32)::nrhs
+ integer(kind=int32)::msglvl_opt
+
+ ! default value if not present
+ msglvl_opt=1
+ if(present(msglvl)) msglvl_opt=msglvl
 
  !$ real(kind=real64)::t1
 
@@ -958,7 +970,7 @@ module subroutine solve_crs_array(sparse,x,y)
   !Preparation of Cholesky of A with Pardiso
   !parvar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=1)   !mtype=11
   !to avoid ifort 2021.4.0 bug
-  sparse%pardisovar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=1)   !mtype=11
+  sparse%pardisovar=pardiso_variable(maxfct=1,mnum=1,mtype=-2,solver=0,msglvl=msglvl_opt)   !mtype=11
 
   !initialize iparm
   call pardisoinit(sparse%pardisovar%pt,sparse%pardisovar%mtype,sparse%pardisovar%iparm)


### PR DESCRIPTION
Dear,

I made some modifications to use the libsparse module:

Added extractor subroutines for CRS objects which allow to extract the row pointers, the column indices and non-zero values:
call A%rowptr(iA)
call A%colval(jA)
call A%nzval(vA)
These subroutines check that the array provided has the same length as the corresponding internal component of the CRS object.

Also added an optional msglvl parameter for the solver subroutines to pass to pardiso.

Lastly, .gitmodule was modified to use HTTPS (so that it can be used without setting up an ssh key in github). If this last modification is an issue, I can remove it and look at the alternatives.